### PR TITLE
Bazel 0.15.2

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,26 +1,23 @@
 # Maintainer: David Ostrovsky <david@ostrovsky.org>
 
 pkgname=bazel
-pkgver=0.13.0
+pkgver=0.15.2
 pkgrel=0
 pkgdesc='Correct, reproducible, and fast builds for everyone'
 arch="all"
 license="ASL-2.0"
 url='https://bazel.io/'
-depends="openjdk8 libarchive zip unzip"
-makedepends="git protobuf python"
+depends="bash openjdk8 libarchive zip unzip"
+makedepends="coreutils git linux-headers protobuf python"
 options="!distcc !strip"
 source="https://github.com/bazelbuild/bazel/releases/download/${pkgver}/bazel-${pkgver}-dist.zip
         https://github.com/bazelbuild/bazel/releases/download/${pkgver}/bazel-${pkgver}-dist.zip.sig"
 
-sha512sums="3c128e551cff1b685250a68892ca3e1ad6be8b152ee2b8eb527c94adbb8fd50c70e703a363bb938916275030ddb14d756c14e4dc238e7a7b40289c700c5d53c7  bazel-0.13.0-dist.zip
-37fd1446e4c9614d66d85d06a9906b2c9bf3026c6f843af913134abff5d7479864813e29a00b8e6875938994022e3736f9d495f360d7fa5e2e2c4db48a2a28f7  bazel-0.13.0-dist.zip.sig"
+sha512sums="c1257fc7eeadc8e76fbd52be393d07161e6eadf7111e09ee9a7f9bf6d3b7e848e9b193a3b66a13e99c09a42e577404cb3a5f1fc3819f35436a36149dbb1ea365  bazel-0.15.2-dist.zip
+d81fd679b9efbd334a32ed4d32561deed7aace24f12462a5860d3fc7b4fc2dfa3614a23f4772e54d06031b364790e91df936d34b1f881ed4067234a8d84cc0b9  bazel-0.15.2-dist.zip.sig"
 
 build() {
   ./compile.sh
-  # Patch bazel: https://github.com/bazelbuild/bazel/issues/4055
-  # https://bugs.alpinelinux.org/issues/8121
-  sed -i.bak 's/expr --/expr/' scripts/generate_bash_completion.sh
   ./output/bazel build -s --verbose_failures scripts:bazel-complete.bash
   cd output
   ./bazel shutdown

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bazel-alpine-package
 
-This is the Bazel 0.13.0 as a Alpine Linux package.
+This is the Bazel 0.15.2 as a Alpine Linux package.
 
 ## Installing
 
@@ -8,5 +8,5 @@ The current installation method for these packages is to pull them in using `wge
 
     apk --no-cache add ca-certificates wget
     wget -q -O /etc/apk/keys/david@ostrovsky.org-5a0369d6.rsa.pub https://raw.githubusercontent.com/davido/bazel-alpine-package/master/david@ostrovsky.org-5a0369d6.rsa.pub
-    wget https://github.com/davido/bazel-alpine-package/releases/download/0.13.0/bazel-0.13.0-r0.apk
-    apk add bazel-0.13.0-r0.apk
+    wget https://github.com/davido/bazel-alpine-package/releases/download/0.15.2/bazel-0.15.2-r0.apk
+    apk add bazel-0.15.2-r0.apk


### PR DESCRIPTION
Tested and working locally with the dockerfile copied below (only requirement is that the APKBUILD file of this PR is present within the docker build context when running `docker build`). I am thinking of adding the dockerfile and automation that results in a docker image tar of the final dockerized bazel build (this would be in a separate PR).

As suggested in bug https://bugs.alpinelinux.org/issues/8121, making coreutils a build dependency allowed the patch to be removed. I also found that I required bash to be installed for bazel to work so made it a dependency for the resulting package.

This is the first time I have used APKBUILD system, any feedback (good or bad) would be very much appreciated.

One thing I am unsure about is the output of `bazel version`:
```
bash-4.4$ bazel version
Extracting Bazel installation...
WARNING: --batch mode is deprecated. Please instead explicitly shut down your Bazel server using the command "bazel shutdown".
Build label: 0.15.2- (@non-git)
Build target: bazel-out/k8-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Wed Jul 18 02:57:56 2018 (1531882676)
Build timestamp: 1531882676
Build timestamp as int: 1531882676
```
Do I have to do anything to get rid of the trailing dash at `Build label: 0.15.2-` and is there anything that can be done to rectify the warning `WARNING: --batch mode is deprecated. Please instead explicitly shut down your Bazel server using the command "bazel shutdown".`?

Here follows the Dockerfile used to validate:
```
FROM alpine:3.8
MAINTAINER Dean Kayton <https://dnk8n.me> <deankayton@gmail.com>
ENV BAZEL_VERSION 0.15.2
RUN \
    apk update && \
    apk --no-cache add alpine-sdk && \
    adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D abuild
USER abuild
WORKDIR /home/abuild
COPY APKBUILD /home/abuild/.
ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
RUN abuild-keygen -a -n && abuild -r

FROM alpine:3.8
MAINTAINER Dean Kayton <https://dnk8n.me> <deankayton@gmail.com>
ENV BAZEL_VERSION 0.15.2
COPY --from=0 /home/abuild/packages/home/x86_64/bazel-${BAZEL_VERSION}-r0.apk .
COPY --from=0 /home/abuild/.abuild/*.rsa.pub /etc/apk/keys/
RUN \
    apk update && \
    apk --no-cache add bazel-${BAZEL_VERSION}-r0.apk && \
    adduser -D bazel -s /bin/bash
USER bazel
WORKDIR /home/bazel
ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
ENTRYPOINT ["bash"]
```